### PR TITLE
Fix for unusual source code locations relative to the include directory.

### DIFF
--- a/src/sync_worker.erl
+++ b/src/sync_worker.erl
@@ -192,15 +192,20 @@ possibly_compile(Module) ->
 find_basedir(A, B) ->
     find_basedir(filename:split(A), filename:split(B), []).
 find_basedir([], _, Acc) ->
-    filename:join(lists:reverse(Acc));
+    find_basedir_acc(Acc);
 find_basedir(_, [], Acc) ->
-    filename:join(lists:reverse(Acc));
+    find_basedir_acc(Acc);
 find_basedir([A|As], [B|Bs], Acc) ->
     case A == B of
         true ->
             find_basedir(As, Bs, [A|Acc]);
         false ->
-            filename:join(lists:reverse(Acc))
+            find_basedir_acc(Acc)
+    end.
+find_basedir_acc(Acc) ->
+    case Acc of
+        [] -> ".";
+        _ -> filename:join(lists:reverse(Acc))
     end.
 
 %% Walk through each option. If it's an include or outdir option, then


### PR DESCRIPTION
This fixes compilation for cases when the include directory is not just one directory up from the source code location.  For example, if I have a project set up like

/project/foo/ebin/foo.beam
/project/foo/include/foo.hrl
/project/foo/src/web/foo.erl

Then it was compiled like:

erlc -o ebin -I include src/web/foo.erl

and foo:module_info() contains

{options, [{i, "include"}]}     (among other things)

Before this change, sync would modify the include directory based on the source file location like:

/project/foo/src/web/../include

Instead, we need to use include relative to the base directory.  In this case, we can find it between the source code and the beam file:

"/project/foo" = find_basedir("/project/foo/ebin/foo.beam", "/project/foo/src/web/foo.erl").
