### PR TITLE
Make backwards compatible with Nitrogen installations using an environment variable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,13 @@ Sync also periodically checks the last modified date of any beam files, and auto
 
 The scanning process adds 1% to 2% CPU load on a running Erlang VM. Much care has been taken to keep this low. Shouldn't have to say this, but this is for development mode only, don't run it in production.
 
+## Using it with Nitrogen
+
+If you are running sync with the [Nitrogen Web Framework](http://www.nitrogenproject.com), be sure to add the following line to your etc/vm.args file:
+
+    -sync sync_mode nitrogen
+
+
 ## Growl Notifications
 
 If you are running a Mac and have [Growl](http://growl.info) and the **growlnotify** utility installed, Sync will pop up Growl notifications with compilation results:


### PR DESCRIPTION
Hey Rusty,

For more info, see my email I sent you yesterday and today.

If you've got a better solution to this particular inconsistency, please let me know and I'll be glad to hack away at it.  This particular mode requires probably the least amount of code changes on your side, and requires a single command-line change for Nitrogen installations.

Thanks man,

-Jesse
