### PR TITLE
Deal with undefined source file options

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -373,7 +373,7 @@ recompile_src_file(SrcFile, EnablePatching) ->
             end;
 
         undefined ->
-            error_logger:error_msg("Unable to determine options for ~p~n", [SrcFile])
+            error_logger:error_msg("Unable to determine options for ~p", [SrcFile])
     end.
 
 


### PR DESCRIPTION
The operation of sync_scanner:rescan/0 has a race on ETS tables (I
believe) where options might be written into the ETS table but an
attempt made to read before the information is committed. When
sync_options:get_options/1 returns undefined sync_scanner will crash,
where it might be better to recover or retry.

This patch attempts no recovery. It only prints a warning and keeps
moving.

Signed-off-by: Brian L. Troutwine brian.troutwine@rackspace.com
