### PR TITLE
Add option to skip success notifications

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -460,11 +460,6 @@ growl_success(Title, Message) ->
 growl_errors(Message) ->
     growl("errors", "Errors...", Message).
 
-growl_errors(Title, Message) ->
-    growl("errors", Title, Message).
-
 growl_warnings(Message) ->
     growl("warnings", "Warnings", Message).
 
-growl_warnings(Title, Message) ->
-    growl("warnings", Title, Message).


### PR DESCRIPTION
Sometimes it becomes annoying.
By this patch success notifications can be turned off (keep only warnings and errors).

btw, this is my first pull-request =)
