### PR TITLE
Mac OS X Notification Center support, for Mountain Lion and higher.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -158,6 +158,7 @@ the `executable` configuration parameter:
 Where `TYPE` is:
 + `'auto'` Autodetermine (default behaviour)
 + `'growlnotify'` for Mac / Growl.
++ `'notification_center'` for Mac OS X built-in Notification Center.
 + `'notify-send'` for Linux / libnotify.
 + `'notifu'` for Windows / Notifu.
 + `'emacsclient'` for Emacs notifications.

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -574,6 +574,10 @@ make_cmd("growlnotify" = Util, Image, Title, Message) ->
     [Util, " -n \"Sync\" --image \"", Image,"\"",
      " -m \"", Message, "\" \"", Title, "\""];
 
+make_cmd("notification_center" = _Util, _Image, Title, Message) ->
+    AppleScript = io_lib:format("display notification \"~s\" with title \"~s\"", [Message, Title]),
+    io_lib:format("osascript -e '~s'", [AppleScript]);
+
 make_cmd("notify-send" = Util, Image, Title, Message) ->
     [Util, " -i \"", Image, "\"",
      " \"", Title, "\" \"", Message, "\" --expire-time=5000"];


### PR DESCRIPTION
Code relies on AppleScript (osascript) to trigger the notification. I think for Mac it should be considered default for auto detect mode, since growl isn't free and is not installed everywhere.

io_lib:format trickery is to make code with quote double escaping a bit easier to read.

Let me know if this works for you or if I need to make some changes.
