### PR TITLE
fix detection of erlang files

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -169,13 +169,13 @@ handle_cast(discover_src_dirs, State) ->
 handle_cast(discover_src_files, State) ->
     %% For each source dir, get a list of source files...
     F = fun(X, Acc) ->
-        sync_utils:wildcard(X, ".*\.erl$") ++ sync_utils:wildcard(X, ".*\.dtl$") ++ Acc
+        sync_utils:wildcard(X, ".*\\.erl$") ++ sync_utils:wildcard(X, ".*\\.dtl$") ++ Acc
     end,
     ErlFiles = lists:usort(lists:foldl(F, [], State#state.src_dirs)),
 
     %% For each include dir, get a list of hrl files...
     Fhrl = fun(X, Acc) ->
-        sync_utils:wildcard(X, ".*\.hrl$") ++ Acc
+        sync_utils:wildcard(X, ".*\\.hrl$") ++ Acc
     end,
     HrlFiles = lists:usort(lists:foldl(Fhrl, [], State#state.hrl_dirs)),
 


### PR DESCRIPTION
While I was diving through the sync source code, I noticed that any file that ends in `erl`, `hrl`, or `dtl` seems to get picked up by `sync_utils:wildcard`. Looks like a slight tweak to the regex in `sync_scanner` fixes this:

Without tweaked regex:

``` erlang
filelib:fold_files(Dir, "\.erl", true, fun(Y, Acc1) -> [Y|Acc1] end, []).
["/Users/danieltrinh/src/oss/sentry/lib/test.herl",
 "/Users/danieltrinh/src/oss/sentry/lib/test.erl"]
```

With tweaked regex:

``` erlang
filelib:fold_files(Dir, "\\.erl", true, fun(Y, Acc1) -> [Y|Acc1] end, []).
["/Users/danieltrinh/src/oss/sentry/lib/test.erl"]
```

I don't know if this actually impacts the end behavior of compiling / reloading erlang code, but it might be useful to merge this for people like me who want to use the actual library code for other applications.
