### PR TITLE
Factor out all of the output into a separate module

### DIFF
--- a/src/sync_notify.erl
+++ b/src/sync_notify.erl
@@ -1,0 +1,155 @@
+%% vim: ts=4 sw=4 et
+
+-module(sync_notify).
+
+%% API
+-export([
+    startup/1,
+    growl_success/1,
+    growl_success/2,
+    growl_errors/1,
+    growl_warnings/1,
+    log_success/1,
+    log_errors/1,
+    log_warnings/1
+]).
+
+startup(Growl) ->
+    case {Growl, os:type()} of
+        {none, _} ->
+            growl_startup_disabled_message();
+        {false, _} -> 
+            growl_startup_disabled_message();
+        _ ->
+            growl_startup_success_message()
+    end.
+
+growl_success(Message) ->
+    growl_success("Success!", Message).
+
+growl_success(Title, Message) ->
+    can_we_growl(success)
+        andalso growl("success", Title, Message).
+
+growl_errors(Message) ->
+    can_we_growl(errors)
+        andalso growl("errors", "Errors...", Message).
+
+growl_warnings(Message) ->
+    can_we_growl(warnings)
+        andalso growl("warnings", "Warnings", Message).
+
+log_success(Message) ->
+    can_we_log(success)
+        andalso error_logger:info_msg(lists:flatten(Message)).
+
+log_errors(Message) ->
+    can_we_log(errors)
+        andalso error_logger:error_msg(lists:flatten(Message)).
+
+log_warnings(Message) ->
+    can_we_log(warnings)
+        andalso error_logger:warning_msg(lists:flatten(Message)).
+
+%%% PRIVATE FUNCTIONS %%%
+
+growl(Image, Title, Message) ->
+    ImagePath = filename:join([filename:dirname(code:which(sync)), "..", "icons", Image]) ++ ".png",
+    Cmd = case sync_utils:get_env(executable, auto) of
+              auto ->
+                  case os:type() of
+                      {win32, _} ->
+                          make_cmd("notifu", ImagePath, Title, Message);
+                      {unix,linux} ->
+                          make_cmd("notify-send", ImagePath, Title, Message);
+                      _ ->
+                          make_cmd("growlnotify", ImagePath, Title, Message)
+                  end;
+              Executable ->
+                  make_cmd(Executable, ImagePath, Title, Message)
+          end,
+    os:cmd(lists:flatten(Cmd)).
+
+make_cmd(Util, Image, Title, Message) when is_atom(Util) ->
+    make_cmd(atom_to_list(Util), Image, Title, Message);
+
+make_cmd("growlnotify" = Util, Image, Title, Message) ->
+    [Util, " -n \"Sync\" --image \"", Image,"\"",
+     " -m \"", Message, "\" \"", Title, "\""];
+
+make_cmd("notification_center" = _Util, _Image, Title, Message) ->
+    AppleScript = io_lib:format("display notification \"~s\" with title \"~s\"", [Message, Title]),
+    io_lib:format("osascript -e '~s'", [AppleScript]);
+
+make_cmd("notify-send" = Util, Image, Title, Message) ->
+    [Util, " -i \"", Image, "\"",
+     " \"", Title, "\" \"", Message, "\" --expire-time=5000"];
+
+make_cmd("notifu" = Util, Image, Title, Message) ->
+    %% see http://www.paralint.com/projects/notifu/
+    [Util, " /q /d 5000 /t ", image2notifu_type(Image), " ",
+     "/p \"", Title, "\" /m \"", Message, "\""];
+
+make_cmd("emacsclient" = Util, "warnings", Title, Message0) ->
+    Message = lisp_format(Message0),
+    io_lib:format("~s --eval \"(mapc (lambda (m) (lwarn \\\"sync: ~s\\\" :warning m)) (list ~s))\"",
+                  [Util, Title, Message]);
+make_cmd("emacsclient" = Util, "errors", Title, Message0) ->
+    Message = lisp_format(Message0),
+    io_lib:format("~s --eval \"(mapc (lambda (m) (lwarn \\\"sync: ~s\\\" :error m)) (list ~s))\"",
+                  [Util, Title, Message]);
+make_cmd("emacsclient" = Util, _, Title, Message0) ->
+    Message = replace_chars(Message0, [{$\n, "\\n"}]),
+    io_lib:format("~s --eval \"(message \\\"[sync] ~s: ~s\\\")\"",
+                  [Util, Title, Message]);
+
+make_cmd(UnsupportedUtil, _, _, _) ->
+    error('unsupported-sync-executable',
+           lists:flatten(io_lib:format("'sync' application environment variable "
+                                       "named 'executable' has unsupported value: ~p",
+                                       [UnsupportedUtil]))).
+
+image2notifu_type("success") -> "info";
+image2notifu_type("warnings") -> "warn";
+image2notifu_type("errors") -> "error".
+
+growl_startup_disabled_message() ->
+    io:format("Growl notifications disabled~n").
+
+growl_startup_success_message() ->
+    growl_success("Sync", "The Sync utility is now running.").
+
+can_we_growl(MsgType) ->
+    can_we_notify(growl, MsgType).
+
+can_we_log(MsgType) ->
+    can_we_notify(log, MsgType).
+
+can_we_notify(GrowlOrLog,MsgType) ->
+    case sync_utils:get_env(GrowlOrLog, all) of
+        true              -> true;
+        all               -> true;
+        none              -> false;
+        false             -> false;
+        skip_success      -> MsgType==errors orelse MsgType==warnings;
+        L when is_list(L) -> lists:member(MsgType, L);
+        _                 -> false
+    end.
+
+%% Return a new string with chars replaced.
+%% @spec replace_chars(iolist(), [{char(), char() | string()}] -> iolist().
+replace_chars(String, Tab) ->
+    lists:map(fun (C) ->
+                      proplists:get_value(C, Tab, C)
+              end,
+              lists:flatten(String)).
+
+%% Return a new string constructed of source lines double quoted and
+%% delimited by space.
+%% spec lisp_format(StringOfLines :: iolist()) -> string().
+lisp_format(String0) ->
+    String1 = lists:flatten(String0),
+    Lines1 = string:tokens(String1, [$\n]),
+    String2 = string:join(Lines1, "\\\" \\\""),
+    lists:flatten(["\\\"", String2, "\\\""]).
+

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -65,8 +65,8 @@ unpause() ->
     ok.
 
 pause() ->
-    log_success("Pausing Sync. Call sync:go() to restart~n"),
-    growl_success("Pausing Sync"),
+    sync_notify:log_success("Pausing Sync. Call sync:go() to restart~n"),
+    sync_notify:growl_success("Pausing Sync"),
     gen_server:cast(?SERVER, pause),
     ok.
 
@@ -77,12 +77,12 @@ info() ->
 
 set_growl(T) when ?LOG_OR_GROWL_ON(T) ->
     sync_utils:set_env(growl,all),
-    growl_success("Sync","Desktop Notifications Enabled"),
+    sync_notify:growl_success("Sync","Desktop Notifications Enabled"),
     sync_utils:set_env(growl,T),
     ok;
 set_growl(F) when ?LOG_OR_GROWL_OFF(F) ->
     sync_utils:set_env(growl,all),
-    growl_success("Sync","Desktop Notifications Disabled"),
+    sync_notify:growl_success("Sync","Desktop Notifications Disabled"),
     sync_utils:set_env(growl,none),
     ok.
 
@@ -91,10 +91,10 @@ get_growl() ->
 
 set_log(T) when ?LOG_OR_GROWL_ON(T) ->
     sync_utils:set_env(log, T),
-    log_success("Console Notifications Enabled~n"),
+    sync_notify:log_success("Console Notifications Enabled~n"),
     ok;
 set_log(F) when ?LOG_OR_GROWL_OFF(F) ->
-    log_success("Console Notifications Disabled~n"),
+    sync_notify:log_success("Console Notifications Disabled~n"),
     sync_utils:set_env(log, none),
     ok.
 
@@ -114,14 +114,7 @@ init([]) ->
     rescan(),
 
     %% Display startup message...
-    case {get_growl(),os:type()} of
-        {none, _} ->
-            growl_startup_disabled_message();
-        {false, _} -> 
-            growl_startup_disabled_message();
-        _ ->
-            growl_startup_success_message()
-    end,
+    sync_notify:startup(get_growl()),
 
     %% Create the state and return...
     State = #state {
@@ -317,8 +310,8 @@ process_beam_lastmod([{Module, _}|T1], [{Module, _}|T2], EnablePatching, {FirstB
     Acc1 = case code:get_object_code(Module) of
         error ->
             Msg = io_lib:format("Error loading object code for ~p~n", [Module]),
-            log_errors(Msg),
-            growl_errors(Msg),
+            sync_notify:log_errors(Msg),
+            sync_notify:growl_errors(Msg),
             {FirstBeam, OtherBeams};
 
         {Module, Binary, Filename} ->
@@ -330,11 +323,11 @@ process_beam_lastmod([{Module, _}|T1], [{Module, _}|T2], EnablePatching, {FirstB
                 true ->
                     {ok, NumNodes} = load_module_on_all_nodes(Module),
                     Msg = io_lib:format("~s: Reloaded on ~p nodes! (Beam changed.)~n", [Module, NumNodes]),
-                    log_success(Msg);
+                    sync_notify:log_success(Msg);
                 false ->
                     %% Print a status message...
                     Msg = io_lib:format("~s: Reloaded! (Beam changed.)~n", [Module]),
-                    log_success(Msg)
+                    sync_notify:log_success(Msg)
             end,
             case FirstBeam of
                undefined -> {Module, OtherBeams};
@@ -362,12 +355,12 @@ process_beam_lastmod([], [], EnablePatching, Acc) ->
             nop; % nothing changed
         {FirstBeam, []} ->
             %% Print a status message...
-            growl_success("Reloaded " ++ atom_to_list(FirstBeam) ++ MsgAdd),
+            sync_notify:growl_success("Reloaded " ++ atom_to_list(FirstBeam) ++ MsgAdd),
             fire_onsync([FirstBeam]);
 
         {FirstBeam, N} ->
             %% Print a status message...
-            growl_success("Reloaded " ++ atom_to_list(FirstBeam) ++
+            sync_notify:growl_success("Reloaded " ++ atom_to_list(FirstBeam) ++
                               " and " ++ integer_to_list(erlang:length(N)) ++ " other beam files" ++ MsgAdd),
             fire_onsync([FirstBeam | N])
     end,
@@ -405,7 +398,7 @@ load_module_on_all_nodes(Module) ->
     F = fun(Node) ->
         io:format("[~s:~p] DEBUG - Node: ~p~n", [?MODULE, ?LINE, Node]),
         Msg = io_lib:format("Reloading '~s' on ~s.~n", [Module, Node]),
-        log_success(Msg),
+        sync_notify:log_success(Msg),
         rpc:call(Node, code, ensure_loaded, [Module]),
         case rpc:call(Node, code, which, [Module]) of
             Filename when is_binary(Filename) orelse is_list(Filename) ->
@@ -417,7 +410,7 @@ load_module_on_all_nodes(Module) ->
                 %% File doesn't exist, just load into VM.
                 {module, Module} = rpc:call(Node, code, load_binary, [Module, undefined, Binary])
         end,
-        growl_success("Reloaded " ++ atom_to_list(Module) ++ " on " ++ atom_to_list(Node) ++ ".")
+        sync_notify:growl_success("Reloaded " ++ atom_to_list(Module) ++ " on " ++ atom_to_list(Node) ++ ".")
     end,
     [F(X) || X <- Nodes],
     {ok, NumNodes}.
@@ -519,7 +512,7 @@ recompile_src_file(SrcFile, _EnablePatching) ->
 
         undefined ->
             Msg = io_lib:format("Unable to determine options for ~p", [SrcFile]),
-            log_errors(Msg)
+            sync_notify:log_errors(Msg)
     end.
 
 
@@ -529,24 +522,24 @@ print_results(Module, SrcFile, [], []) ->
         {file, _} ->
             ok;
         false ->
-            growl_success("Recompiled " ++ SrcFile ++ ".")
+            sync_notify:growl_success("Recompiled " ++ SrcFile ++ ".")
     end,
-    log_success(lists:flatten(Msg));
+    sync_notify:log_success(lists:flatten(Msg));
 
 print_results(_Module, SrcFile, [], Warnings) ->
     Msg = [
         format_errors(SrcFile, [], Warnings),
         io_lib:format("~s:0: Recompiled with ~p warnings~n", [SrcFile, length(Warnings)])
     ],
-    growl_warnings(growl_format_errors([], Warnings)),
-    log_warnings(Msg);
+    sync_notify:growl_warnings(growl_format_errors([], Warnings)),
+    sync_notify:log_warnings(Msg);
 
 print_results(_Module, SrcFile, Errors, Warnings) ->
     Msg = [
         format_errors(SrcFile, Errors, Warnings)
     ],
-    growl_errors(growl_format_errors(Errors, Warnings)),
-    log_errors(Msg).
+    sync_notify:growl_errors(growl_format_errors(Errors, Warnings)),
+    sync_notify:log_errors(Msg).
 
 
 %% @private Print error messages in a pretty and user readable way.
@@ -574,133 +567,6 @@ growl_format_errors(Errors, Warnings) ->
         io_lib:format("~p: ~s: ~s~n", [Line, Prefix, Msg])
     end,
     [F(X) || X <- Everything].
-
-growl(Image, Title, Message) ->
-    ImagePath = filename:join([filename:dirname(code:which(sync)), "..", "icons", Image]) ++ ".png",
-    Cmd = case sync_utils:get_env(executable, auto) of
-              auto ->
-                  case os:type() of
-                      {win32, _} ->
-                          make_cmd("notifu", ImagePath, Title, Message);
-                      {unix,linux} ->
-                          make_cmd("notify-send", ImagePath, Title, Message);
-                      _ ->
-                          make_cmd("growlnotify", ImagePath, Title, Message)
-                  end;
-              Executable ->
-                  make_cmd(Executable, ImagePath, Title, Message)
-          end,
-    os:cmd(lists:flatten(Cmd)).
-
-make_cmd(Util, Image, Title, Message) when is_atom(Util) ->
-    make_cmd(atom_to_list(Util), Image, Title, Message);
-
-make_cmd("growlnotify" = Util, Image, Title, Message) ->
-    [Util, " -n \"Sync\" --image \"", Image,"\"",
-     " -m \"", Message, "\" \"", Title, "\""];
-
-make_cmd("notification_center" = _Util, _Image, Title, Message) ->
-    AppleScript = io_lib:format("display notification \"~s\" with title \"~s\"", [Message, Title]),
-    io_lib:format("osascript -e '~s'", [AppleScript]);
-
-make_cmd("notify-send" = Util, Image, Title, Message) ->
-    [Util, " -i \"", Image, "\"",
-     " \"", Title, "\" \"", Message, "\" --expire-time=5000"];
-
-make_cmd("notifu" = Util, Image, Title, Message) ->
-    %% see http://www.paralint.com/projects/notifu/
-    [Util, " /q /d 5000 /t ", image2notifu_type(Image), " ",
-     "/p \"", Title, "\" /m \"", Message, "\""];
-
-make_cmd("emacsclient" = Util, "warnings", Title, Message0) ->
-    Message = lisp_format(Message0),
-    io_lib:format("~s --eval \"(mapc (lambda (m) (lwarn \\\"sync: ~s\\\" :warning m)) (list ~s))\"",
-                  [Util, Title, Message]);
-make_cmd("emacsclient" = Util, "errors", Title, Message0) ->
-    Message = lisp_format(Message0),
-    io_lib:format("~s --eval \"(mapc (lambda (m) (lwarn \\\"sync: ~s\\\" :error m)) (list ~s))\"",
-                  [Util, Title, Message]);
-make_cmd("emacsclient" = Util, _, Title, Message0) ->
-    Message = replace_chars(Message0, [{$\n, "\\n"}]),
-    io_lib:format("~s --eval \"(message \\\"[sync] ~s: ~s\\\")\"",
-                  [Util, Title, Message]);
-
-make_cmd(UnsupportedUtil, _, _, _) ->
-    error('unsupported-sync-executable',
-           lists:flatten(io_lib:format("'sync' application environment variable "
-                                       "named 'executable' has unsupported value: ~p",
-                                       [UnsupportedUtil]))).
-
-image2notifu_type("success") -> "info";
-image2notifu_type("warnings") -> "warn";
-image2notifu_type("errors") -> "error".
-
-growl_startup_disabled_message() ->
-    io:format("Growl notifications disabled~n").
-
-growl_startup_success_message() ->
-    growl_success("Sync", "The Sync utility is now running.").
-
-growl_success(Message) ->
-    growl_success("Success!", Message).
-
-growl_success(Title, Message) ->
-    can_we_growl(success)
-        andalso growl("success", Title, Message).
-
-growl_errors(Message) ->
-    can_we_growl(errors)
-        andalso growl("errors", "Errors...", Message).
-
-growl_warnings(Message) ->
-    can_we_growl(warnings)
-        andalso growl("warnings", "Warnings", Message).
-
-log_success(Message) ->
-    can_we_log(success)
-        andalso error_logger:info_msg(lists:flatten(Message)).
-
-log_errors(Message) ->
-    can_we_log(errors)
-        andalso error_logger:error_msg(lists:flatten(Message)).
-
-log_warnings(Message) ->
-    can_we_log(warnings)
-        andalso error_logger:warning_msg(lists:flatten(Message)).
-
-can_we_growl(MsgType) ->
-    can_we_notify(growl, MsgType).
-
-can_we_log(MsgType) ->
-    can_we_notify(log, MsgType).
-
-can_we_notify(GrowlOrLog,MsgType) ->
-    case sync_utils:get_env(GrowlOrLog, all) of
-        true              -> true;
-        all               -> true;
-        none              -> false;
-        false             -> false;
-        skip_success      -> MsgType==errors orelse MsgType==warnings;
-        L when is_list(L) -> lists:member(MsgType, L);
-        _                 -> false
-    end.
-
-%% Return a new string with chars replaced.
-%% @spec replace_chars(iolist(), [{char(), char() | string()}] -> iolist().
-replace_chars(String, Tab) ->
-    lists:map(fun (C) ->
-                      proplists:get_value(C, Tab, C)
-              end,
-              lists:flatten(String)).
-
-%% Return a new string constructed of source lines double quoted and
-%% delimited by space.
-%% spec lisp_format(StringOfLines :: iolist()) -> string().
-lisp_format(String0) ->
-    String1 = lists:flatten(String0),
-    Lines1 = string:tokens(String1, [$\n]),
-    String2 = string:join(Lines1, "\\\" \\\""),
-    lists:flatten(["\\\"", String2, "\\\""]).
 
 process_hrl_file_lastmod([{File, LastMod}|T1], [{File, LastMod}|T2], SrcFiles, Patching) ->
     %% Hrl hasn't changed, do nothing...


### PR DESCRIPTION
No new functionality -- just a refactoring.  Easier to read and beef up the notification logic in the future.  Manual testing looks ok on `{unix,linux}` 
