### PR TITLE
custom source and destanation directories support. Recompile files even if they were changed while sync is stopped

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,13 +14,24 @@ recompiles the code, and reloads the module.
 
 ## How can I use Sync?
 
-The recommended approach is to put sync in your $ERL_LIBS directory.
+### Install via rebar dependency
+
+```erlang
+{deps, [
+		{sync, ".*",
+			{git, "git@github.com:lol4t0/sync.git", {branch, "master"}}}
+]}.
+```
+
+### Manual install
 
 ```bash
 cd $ERL_LIBS
 git clone git@github.com:rustyio/sync.git
 (cd sync; make)
 ```
+
+The recommended approach is to put sync in your $ERL_LIBS directory.
 
 Then, go in the Erlang console of an application you are developing, run
 `sync:go().`. You can also start sync using `application:start(sync).`
@@ -68,6 +79,36 @@ everything is complete. Calling `sync:go()` once again will unpause the scanner.
 
 Bear in mind that running `pause()` will not stop files that are currently
 being compiled.
+
+## Specifying folders to sync
+
+To your erlang `config` add
+
+```erlang
+[
+    {sync, [
+        {src_dirs, {strategy(), [src_dir_descr()]}}
+    ]}
+].
+```
+```erlang
+-type strategy() :: add | replace.
+````
+If `strategy()` is `replace`, sync will use ONLY specified dirs to sync. If `strategy()` is `add`, sync will add specific dirs to list of dirs to sync.
+
+```erlang
+-type src_dir_descr() :: { Dir :: file:filename(), [Options :: compile_option()]}.
+```
+You probably want to specify `outdir` compile option.
+
+For example
+```erlang
+[
+    {sync, [
+        {src_dirs, {replace, [{"./priv/plugins", [{outdir,"./priv/plugins_bin"}]}]}}
+    ]}
+].
+```
 
 ## Console Logging
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, fail_on_warning]}.

--- a/src/sync.erl
+++ b/src/sync.erl
@@ -99,7 +99,7 @@ stop(_State) ->
 
 init([]) ->
     %% Return.
-    {ok, { {one_for_one, 5, 10}, [
-        ?CHILD(sync_scanner, worker),
-        ?CHILD(sync_options, worker)
+    {ok, { {rest_for_one, 5, 10}, [
+        ?CHILD(sync_options, worker),
+        ?CHILD(sync_scanner, worker)
     ]} }.

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -43,7 +43,7 @@
     hrl_files = [] :: [file:filename()],
     beam_lastmod = undefined :: [{module(), timestamp()}],
     src_file_lastmod = [] :: [{file:filename(), timestamp()}],
-    hrl_file_lastmod = undefined :: [{file:filename(), timestamp()}],
+    hrl_file_lastmod = [] :: [{file:filename(), timestamp()}],
     timers = [],
     patching = false,
     paused = false
@@ -602,10 +602,10 @@ process_hrl_file_lastmod([{File1, LastMod1}|T1], [{File2, LastMod2}|T2], SrcFile
             [maybe_recompile_src_file(SrcFile, LastMod2, Patching) || SrcFile <- WhoInclude],
             process_hrl_file_lastmod([{File1, LastMod1}|T1], T2, SrcFiles, Patching)
     end;
-process_hrl_file_lastmod([], [{File, _LastMod}|T2], SrcFiles, Patching) ->
+process_hrl_file_lastmod([], [{File, LastMod}|T2], SrcFiles, Patching) ->
     %% File is new, look for src that include it
     WhoInclude = who_include(File, SrcFiles),
-    [recompile_src_file(SrcFile, Patching) || SrcFile <- WhoInclude],
+    [maybe_recompile_src_file(SrcFile, LastMod, Patching) || SrcFile <- WhoInclude],
     process_hrl_file_lastmod([], T2, SrcFiles, Patching);
 process_hrl_file_lastmod([], [], _, _) ->
     %% Done

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -43,7 +43,7 @@
     hrl_files = [] :: [file:filename()],
     beam_lastmod = undefined :: [{module(), timestamp()}],
     src_file_lastmod = [] :: [{file:filename(), timestamp()}],
-    hrl_file_lastmod = [] :: [{file:filename(), timestamp()}],
+    hrl_file_lastmod = undefined :: [{file:filename(), timestamp()}],
     timers = [],
     patching = false,
     paused = false


### PR DESCRIPTION
1. This will let user to specify directories to sync. Even if there were no modules on sync start loaded, that point to that directories, directories will be tracked and files will be compiled. If modules from directories compile to nonstandard destination path, those path will be added to erlang code path list.

 This feature let use sync as a plugins host. So sync tracks plugins folder and loads everything from that folder as user add new files there.

 See readme for usage description.

2. Recompile beams on sync start even they were changed while sync was turned off.