### PR TITLE
Avoid XRef messages saying 'undefined function'

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -439,11 +439,13 @@ erlydtl_compile(SrcFile, Options) ->
     Module =
         list_to_atom(
             lists:flatten(filename:basename(SrcFile, ".dtl") ++ "_dtl")),
-    erlydtl:compile(SrcFile, Module, DtlOptions).
+    Compiler = erlydtl,
+    Compiler:compile(SrcFile, Module, DtlOptions).
 
 elixir_compile(SrcFile, Options) ->
     Outdir = proplists:get_value(outdir, Options),
-    Modules = 'Elixir.Kernel.ParallelCompiler':files_to_path([list_to_binary(SrcFile)], list_to_binary(Outdir)),
+    Compiler = 'Elixir.Kernel.ParallelCompiler',
+    Modules = Compiler:files_to_path([list_to_binary(SrcFile)], list_to_binary(Outdir)),
     Loader = fun(Module) ->
         Outfile = code:which(Module),
         Binary = file:read_file(Outfile),


### PR DESCRIPTION
When I use sync in my project I have an xref error:
src/sync_scanner.erl:444: Warning elixir_compile/2 calls undefined function Elixir.Kernel.ParallelCompiler:files_to_path/2
src/sync_scanner.erl:432: Warning erlydtl_compile/2 calls undefined function erlydtl:compile/3

To avoid that message, just trick the xref compiler :)