### PR TITLE
Add syntax_tools to erlang dependecy for epp_dodger

### DIFF
--- a/src/sync.app.src
+++ b/src/sync.app.src
@@ -1,7 +1,7 @@
 % vim: ts=4 sw=4 et ft=erlang
 {application, sync, [
     {description, "Sync - Automatic Code Reloader"},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, syntax_tools]},
     {vsn, "0.1.3"},
     {registered, []},
     {mod, { sync, []}},


### PR DESCRIPTION
I see:
```
** Reason for termination == 
** {'module could not be loaded',
       [{epp_dodger,parse_file,
            ["/home/thinker/develop/thinker_home/deps/cowboy/src/cowboy.erl"],
            []},
        {sync_scanner,'-who_include/2-fun-0-',2,
            [{file,"src/sync_scanner.erl"},{line,663}]},
        {lists,'-filter/2-lc$^0/1-0-',2,[{file,"lists.erl"},{line,1284}]},
        {sync_scanner,process_hrl_file_lastmod,4,
            [{file,"src/sync_scanner.erl"},{line,650}]},
        {sync_scanner,handle_cast,2,
            [{file,"src/sync_scanner.erl"},{line,225}]},
        {gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,599}]},
        {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}
```
for lastest sync lib