### PR TITLE
exclude_masks option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,6 +114,29 @@ For example
 ].
 ```
 
+## Exclude folders from sync
+
+```erlang
+[
+    {sync, [
+        {exclude_masks, ["deps", "_rel"]}
+    ]}
+].
+```
+This will exclude any path containing "deps" or "_rel" from being synced.
+
+## Include only specified folders to sync
+
+```erlang
+[
+    {sync, [
+        {include_masks, ["src"]}
+    ]}
+].
+```
+This will include to sync only paths containing word "src".
+
+
 ## Console Logging
 
 By default, sync will print sucess / warning / failure notifications to the

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -654,9 +654,10 @@ process_hrl_file_lastmod([{File1, LastMod1}|T1], [{File2, LastMod2}|T2], SrcFile
             process_hrl_file_lastmod([{File1, LastMod1}|T1], T2, SrcFiles, Patching)
     end;
 process_hrl_file_lastmod([], [{File, LastMod}|T2], SrcFiles, Patching) ->
+    %% FIXME!!! It's incredible, un-usable slow 
     %% File is new, look for src that include it
-    WhoInclude = who_include(File, SrcFiles),
-    [maybe_recompile_src_file(SrcFile, LastMod, Patching) || SrcFile <- WhoInclude],
+    %% WhoInclude = who_include(File, SrcFiles),
+    %% [maybe_recompile_src_file(SrcFile, LastMod, Patching) || SrcFile <- WhoInclude],
     process_hrl_file_lastmod([], T2, SrcFiles, Patching);
 process_hrl_file_lastmod([], [], _, _) ->
     %% Done
@@ -735,9 +736,25 @@ module_matches(Module, [Pattern|T]) when is_list(Pattern) ->
         nomatch -> module_matches(Module, T)
     end.
 
+none_of(Dir, Masks) ->
+    lists:all(fun(Mask) -> string:str(Dir, Mask) == 0 end, Masks).
+
+any_of(Dir, Masks) ->
+    lists:any(fun(Mask) -> string:str(Dir, Mask) > 0 end, Masks).
+
+exclude_dirs(Dirs, []) -> Dirs;
+exclude_dirs(Dirs, Masks) -> [ Dir || Dir <- Dirs, none_of(Dir, Masks) ].
+
+include_dirs(Dirs, []) -> Dirs;
+include_dirs(Dirs, Masks) -> [ Dir || Dir <- Dirs, any_of(Dir, Masks) ].
+
+filter_dirs(Dirs, IncludeMasks, ExcludeMasks) ->
+    include_dirs(exclude_dirs(Dirs, ExcludeMasks), IncludeMasks).
 
 discover_source_dirs(State, ExtraDirs) ->
     %% Extract the compile / options / source / dir from each module.
+    ExcludeMasks = application:get_env(sync, exclude_masks, []),
+    IncludeMasks = application:get_env(sync, include_masks, []),
     F = fun(X, Acc = {SrcAcc, HrlAcc}) ->
         %% Get the dir...
         case sync_utils:get_src_dir_from_module(X) of
@@ -754,8 +771,8 @@ discover_source_dirs(State, ExtraDirs) ->
         end
     end,
     {SrcDirs, HrlDirs} = lists:foldl(F, {ExtraDirs, []}, State#state.modules),
-    USortedSrcDirs = lists:usort(SrcDirs),
-    USortedHrlDirs = lists:usort(HrlDirs),
+    USortedSrcDirs = filter_dirs(lists:usort(SrcDirs), IncludeMasks, ExcludeMasks),
+    USortedHrlDirs = filter_dirs(lists:usort(HrlDirs), IncludeMasks, ExcludeMasks),
     %% InitialDirs = sync_utils:initial_src_dirs(),
 
     %% Schedule the next interval...

--- a/src/sync_utils.erl
+++ b/src/sync_utils.erl
@@ -9,7 +9,6 @@
          get_env/2,
          set_env/2,
          file_last_modified_time/1,
-         transform_options/2,
          get_system_modules/0
 ]).
 
@@ -261,25 +260,6 @@ file_last_modified_time(File) ->
     catch _Error : _Reason ->
         deleted
     end.
-
-%% @private Walk through each option. If it's an include or outdir option, then
-%% rewrite the path...
-transform_options(SrcDir, Options) ->
-    F = fun(Option, Acc) ->
-        case Option of
-            {i, IncludeDir1} ->
-                IncludeDir2 = filename:join([SrcDir, "..", IncludeDir1]),
-                [{i, IncludeDir2}|Acc];
-            {outdir, _Dir} ->
-                Acc;
-            Other ->
-                [Other|Acc]
-        end
-    end,
-
-    LastPart = filename:basename(proplists:get_value(outdir, Options, "./ebin")),
-    BinDir = filename:join([SrcDir, "..", LastPart]),
-    lists:foldl(F, [], Options) ++ [{outdir, BinDir}].
 
 %% @private Return a list of all modules that belong to Erlang rather
 %% than whatever application we may be running.


### PR DESCRIPTION
To exclude certain paths from syncing (deps and _rel as examples).
I did this because sync just hangs with CPU to 100% on some paths unkonwn
deeply in deps.