### PR TITLE
Edge case bug crashes sync_scanner

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -330,7 +330,7 @@ process_beam_lastmod([{Module1, LastMod1}|T1], [{Module2, LastMod2}|T2], EnableP
         false ->
             process_beam_lastmod([{Module1, LastMod1}|T1], T2, EnablePatching, Acc)
     end;
-process_beam_lastmod([], [], EnablePatching, Acc) ->
+process_beam_lastmod(A, B, EnablePatching, Acc) when A =:= []; B =:= [] ->
     MsgAdd = case EnablePatching of
                  true -> " on " ++ integer_to_list(length(get_nodes())) ++ " nodes.";
                  false -> "."


### PR DESCRIPTION
While working up another pull request, I stumbled upon this edge case bug...

If either the old or the new beam lastmod list gets exhausted before the other during `process_beam_lastmod`, sync_scanner crashes with a function clause error, e.g.:

_gen_server sync_scanner terminated with reason: no function clause matching sync_scanner:process_beam_lastmod([], [{zzz,{{2016,10,15},{18,44,35}}}], false, {undefined,[]}) line 294_

This has probably gone unnoticed because zlib is _usually_ a preloaded module that sorts to the end of both lists as the final module to compare, resulting in both lists being exhausted together.

Steps to reproduce:
1. Create and compile a simple module which will get sorted to the end of the loaded module list, for example:
   `echo '-module(zzz).' > zzz.erl`
   `erl -compile zzz.erl`
2. Start up an erlang shell with sync configured and in the code path.
3. Start up sync, wait for at least one module discovery to run, and finally load the new 'zzz' module.  On the next `compare_beams` sync_scanner should crash.
   `1> sync:go().`
   `1> %% Wait...`
   `1> l(zzz).`
