### PR TITLE
fix if outdir occurs more than once

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -439,12 +439,10 @@ process_src_file_lastmod(undefined, _Other, _) ->
 
 
 erlydtl_compile(SrcFile, Options) ->
-    DtlOptions =
-        case lists:keytake(outdir, 1, Options) of
-            false -> Options;
-            {value, {outdir, OutDir}, OtherOptions} ->
-                [{out_dir, OutDir} | OtherOptions]
+    F = fun({outdir, OutDir}, Acc) -> [{out_dir, OutDir} | Acc];
+           (OtherOption, Acc) -> [OtherOption | Acc]
         end,
+    DtlOptions = lists:foldl(F, [], Options),
     Module =
         list_to_atom(
             lists:flatten(filename:basename(SrcFile, ".dtl") ++ "_dtl")),


### PR DESCRIPTION
I have a situation when outdir is occurs more than once. Perhaps this is due to the use of erlang.mk and relx. This is my DtlOptions:
```
[{type,dtl},
{out_dir,"/home/developer/okfilm/raspberry_server/_rel/raspberry_server/lib/raspberry_server-3.0.0/ebin"},
{out_dir,"."},
{i,"/home/developer/okfilm/raspberry_server/include"},
{i,"/home/developer/okfilm/raspberry_server/_rel/raspberry_server/lib/raspberry_server-3.0.0/include"},
nowarn_shadow_vars]
```