### PR TITLE
Issue 78: Enhance scoped directory sync options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: erlang
 script: "make travis"
 otp_release:
-  - R16B02
-  - R16B01
-  - R16B
-  - R15B03
-  - R15B02
-  - R15B01
-  - R15B
+  - 21.0.3
+  - 20.3
+  - 19.3
+  - 18.3
+  - 17.3
+  - R16B03

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,9 @@ ERLANG_VERSION = $(shell $(ERLANG_VERSION_CHECK))
 # This is primarily for Travis build testing, as each build instruction will overwrite the previous
 travis: $(ERLANG_VERSION)
 
-R15B: dialyzer
-R15B01: dialyzer
-R15B02: dialyzer-no-race
-R15B03: dialyzer
-R16B: dialyzer
-R16B01: dialyzer
-R16B02: dialyzer
+R16B03: dialyzer
+17: dialyzer
+18: dialyzer
+19: dialyzer
+20: dialyzer
+21: dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,1 @@
-{erl_opts, [debug_info, fail_on_warning]}.
+{erl_opts, [debug_info]}.

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -2,7 +2,7 @@
 
 -module(sync_scanner).
 -behaviour(gen_server).
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 %% API
 -export([
@@ -41,7 +41,7 @@
     src_files = [] :: [file:filename()],
     hrl_dirs = [] :: [file:filename()],
     hrl_files = [] :: [file:filename()],
-    beam_lastmod = undefined :: [{module(), timestamp()}],
+    beam_lastmod = undefined :: [{module(), timestamp()}] | undefined,
     src_file_lastmod = [] :: [{file:filename(), timestamp()}],
     hrl_file_lastmod = [] :: [{file:filename(), timestamp()}],
     timers = [],

--- a/src/sync_utils.erl
+++ b/src/sync_utils.erl
@@ -13,7 +13,15 @@
          get_system_modules/0
 ]).
 
--compile(export_all).
+-ifdef(OTP_RELEASE). %% this implies 21 or higher
+-define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
+-define(GET_STACK(Stacktrace), Stacktrace).
+-else.
+-define(EXCEPTION(Class, Reason, _), Class:Reason).
+-define(GET_STACK(_), erlang:get_stacktrace()).
+-endif.
+
+-compile([export_all, nowarn_export_all]).
 
 get_src_dir_from_module(Module)->
     case code:is_loaded(Module) of
@@ -88,12 +96,12 @@ get_options_from_module(Module) ->
 
                 Options4 = [{i_list, IncludeDirList1}, {type, Type} | Options2],
                 {ok, Options4}
-            catch ExType:Error ->
+            catch ?EXCEPTION(ExType, Error, Stacktrace) ->
                 Msg =
                     [
                         io_lib:format(
                             "~p:0: ~p looking for options: ~p. Stack: ~p~n",
-                            [Module, ExType, Error, erlang:get_stacktrace()])
+                            [Module, ExType, Error, ?GET_STACK(Stacktrace)])
                     ],
                 sync_notify:log_warnings(Msg),
                 {ok, []}


### PR DESCRIPTION
Issue has been detailed at: https://github.com/rustyio/sync/issues/78

Found that add strategy and default strategy(no strategy) goes through discover_source_dirs() to figure out compile time options for compiling a file. Doing the same for "replace" strategy option as well.