### PR TITLE
Modify the default value of get_growl to 'none'

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -89,7 +89,7 @@ set_growl(F) when ?LOG_OR_GROWL_OFF(F) ->
     ok.
 
 get_growl() ->
-    sync_utils:get_env(growl, all).
+    sync_utils:get_env(growl, none).
 
 set_log(T) when ?LOG_OR_GROWL_ON(T) ->
     sync_utils:set_env(log, T),


### PR DESCRIPTION
When we run sync in a virtual environment, using 'notify-send' will prevent us from exiting the terminal.so I need to mandatory exit using ctrl + c

