### PR TITLE
Issue 89: Adding new sync_method - fsevents

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,5 @@
 {erl_opts, [debug_info]}.
+
+{deps, [
+    {fs, "6.1.1"}
+]}.

--- a/src/sync.app.src
+++ b/src/sync.app.src
@@ -8,6 +8,11 @@
     {maintainers, ["Jesse Gumm", "Heinz N. Gies"]},
     {licenses, ["MIT"]},
     {links, [{"Github", "https://github.com/rustyio/sync"}]},
+    {applications, [
+        kernel,
+        stdlib,
+        fs
+    ]},
     {env, [
         {discover_modules_interval,  10000},
         {discover_src_dirs_interval, 10000},


### PR DESCRIPTION
Issue has been detailed at: https://github.com/rustyio/sync/issues/89

Currently sync polls directories and files for any changes and recompile the changed files and loads them. When sync starts monitoring more projects under one umbrella CPU can get overwhelmed with this polling. it will be good if sync looks for file system changes notifications and act upon them.

There is a project synrc/fs which provides filesystem change events. This supports Mac, Windows and Linux platforms.

This commit integrates sync with fs. Here is what it does:

1. Added a new app evnironment variable, sync_method. User can specifiy this to scanner or fsevents. By default it will be scanner, which would retain current behavior. If user specifies fsevents, new logic kicks in.
2. discover_src_dirs, will discover all source directories as requested by user. and starts fs process for monited directories.
3. When a source file or a header file changes, sync gets {fs,file_event} event. And it will handle the changed files a second later so that it can suppress/collect all events on a file.
4. Make sure no timers are active in stable state.

Signed-off-by: Vasu Dasari <vdasari@gmail.com>