### PR TITLE
Spawn compiler process to avoid disruption by fs events

### DIFF
--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -621,7 +621,9 @@ recompile_src_file(SrcFile, _EnablePatching) ->
     OldBinary = get_object_code(Module),
 
     case sync_options:get_options(SrcDir) of
-        {ok, Options} ->
+        {ok, Options0} ->
+            %% Event messages from fs may disrupt compile module, spawn it
+            Options = lists:delete(no_spawn_compiler_process, Options0),
             case CompileFun(SrcFile, [binary, return|Options]) of
                 {ok, Module, Binary, Warnings} ->
                     reload_if_necessary(CompileFun, SrcFile, Module, OldBinary, Binary, Options, Warnings);

--- a/src/sync_scanner.erl
+++ b/src/sync_scanner.erl
@@ -581,7 +581,15 @@ reload_if_necessary(_CompileFun, SrcFile, Module, Binary, Binary, _Options, Warn
 
 reload_if_necessary(CompileFun, SrcFile, Module, _OldBinary, _Binary, Options, Warnings) ->
     %% Compiling changed the beam code. Compile and reload.
-    CompileFun(SrcFile, Options),
+    case CompileFun(SrcFile, [return | Options]) of
+        {ok, _} ->
+            ok;
+        {ok, _, _} ->
+            ok;
+        CompileResult ->
+            sync_notify:log_warnings("Compile failed in reload_if_necessary(): ~p~n",
+                                     [CompileResult])
+    end,
     %% Try to load the module...
     case code:ensure_loaded(Module) of
         {module, Module} -> ok;


### PR DESCRIPTION
Original issue: sync does not reload modules after corresponding files are modified, with fsevents.

In debugging it, I observed the second compilation in reload_if_necessary() failed.
The first commit  https://github.com/rustyio/sync/commit/a071a986da2524cc0ce62da95ee43d190d4b88d4 just adds warning log how the failure reason looks like.

The message was:

```
2022-05-02T05:24:52.113782Z [warning] [-/-/-] Compile failed in reload_if_necessary(): {error, [{"/home/shino/g/sora/src/sora_misc.erl", [{none,compile, {crash,parse_module,badarg, [{erlang,'--', [{<0.468.0>, {fs,file_event}, {"/home/shino/g/sora/_build/dev/lib/sora/ebin/sora_misc.beam", [deleted]}}, []], [{error_info, #{module =>, erl_erts_errors}}]}, {compile, metadata_add_features,2, [{file,"compile.erl"}, {line,1068}]}, {compile,do_parse_module,2, [{file,"compile.erl"}, {line,1037}]}, {compile,parse_module,2, [{file,"compile.erl"}, {line,994}]}, {compile,fold_comp,4, [{file,"compile.erl"}, {line,405}]}, {compile,internal_comp,5, [{file,"compile.erl"}, {line,389}]}, {compile, '-internal_fun/2-anonymous-0-', 2, [{file,"compile.erl"}, {line,227}]}, {sync_scanner, reload_if_necessary,7, [{file, "/home/shino/g/sora/_checkouts/sync/src/sync_scanner.erl"}, {line,584}]}, {sync_scanner, '-handle_cast/2-fun-7-',2, [{file, "/home/shino/g/sora/_checkouts/sync/src/sync_scanner.erl"}, {line,271}]}, {sync_scanner, '-handle_cast/2-fun-9-',5, [{file, "/home/shino/g/sora/_checkouts/sync/src/sync_scanner.erl"}, {line,280}]}, {lists,foldl_1,3, [{file,"lists.erl"}, {line,1355}]}, {sync_scanner,handle_cast,2, [{file, "/home/shino/g/sora/_checkouts/sync/src/sync_scanner.erl"}, {line,276}]}, {gen_server,try_dispatch,4, [{file,"gen_server.erl"}, {line,1120}]}, {gen_server,handle_msg,6, [{file,"gen_server.erl"}, {line,1197}]}, {proc_lib,init_p_do_apply,3, [{file,"proc_lib.erl"}, {line,240}]}]}}]}], []}
```

This seems like events from fs library.

So the second commit removes `no_spawn_compiler_process` from compiler option list.

------------

My environment:
- Linux
- Erlang OTP 25.0 rc3
- sync v0.2.0