### PR TITLE
Add dependency to nitrogen_core

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {fs, "6.1.1"}
+    {fs, "6.1.1"},
+    {nitrogen_core, "2.4.0"}
 ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -10,6 +10,6 @@ case erlang:function_exported(rebar3, main, 1) of
         %% profiles
         [{deps, [
             {fs, "", {git, "https://github.com/synrc/fs", {tag, "6.1"}}},
-            {nitrogen_core, "", {git, "https://github.com/nitrogen/nitrogen_core", {tag, "2.4.0"}}}
+            {nitrogen_core, "", {git, "https://github.com/nitrogen/nitrogen_core", {tag, "v2.4.0"}}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -9,6 +9,7 @@ case erlang:function_exported(rebar3, main, 1) of
         %% Rebuild deps, possibly including those that have been moved to
         %% profiles
         [{deps, [
-            {fs, "", {git, "https://github.com/synrc/fs", {tag, "6.1"}}}
+            {fs, "", {git, "https://github.com/synrc/fs", {tag, "6.1"}}},
+            {nitrogen_core, "", {git, "https://github.com/nitrogen/nitrogen_core", {tag, "2.4.0"}}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.


### PR DESCRIPTION
Standalone sync app crashes because sync_scanner now also uses the wf module from nitrogen_core for formatting errors